### PR TITLE
Add support for snapshot and repeated plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ go test -v -timeout 4h ./test/jibu/... -args -ginkgo.v \
 -jibu-tenant=369641743475338021 \
 -jibu-api-endpoint="http://103.33.66.159:33800"
 ```
+
+```shell
+go test -v -timeout 4h ./test/jibu/... -args -ginkgo.v -jibu-tenant=381577994897986984 -jibu-api-endpoint="http://192.168.0.15:31800" -jibu-backup-repeat-enabled=true -jibu-backup-method=snapshot -jibu-backup-frequency="*/1 * * * *" -jibu-backup-namespace=kubesphere-monitoring-system -jibu-restore-namespace=kubesphere-monitoring-system
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/elliotchance/pie v1.39.0
-	github.com/jibutech/backup-saas-client v0.0.2-0.20211122080547-dd7799d24aa6
+	github.com/jibutech/backup-saas-client v0.0.2-0.20211210113648-e89028c38b38
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	k8s.io/apimachinery v0.22.4
@@ -12,36 +12,15 @@ require (
 )
 
 require (
-	github.com/antihax/optional v1.0.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-logr/logr v1.2.0 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/antihax/optional v1.0.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
+	github.com/robfig/cron/v3 v3.0.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
-	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
-	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.22.4 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
-	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -77,7 +77,6 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -125,12 +124,10 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -159,12 +156,9 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/jibutech/backup-saas-client v0.0.1 h1:L4RNlBaSxdBAtipZdRTiwe/jK02sZ68G/yPVSTq7adU=
-github.com/jibutech/backup-saas-client v0.0.1/go.mod h1:/kjnmuqsMF2L4pxwT/1a236X35mrgCbbq5fZpQ7isYU=
-github.com/jibutech/backup-saas-client v0.0.2-0.20211122080547-dd7799d24aa6 h1:6mp/qcWdBF/tn5CDPZL+p1k2xL83sN/8vijb5ew+Q9w=
-github.com/jibutech/backup-saas-client v0.0.2-0.20211122080547-dd7799d24aa6/go.mod h1:AXpj+/dCZ5hSmV9tg4yFQLAKGRsAyf9lhCxwA+4pMy8=
+github.com/jibutech/backup-saas-client v0.0.2-0.20211210113648-e89028c38b38 h1:MMJVySO+a2KurGDPsR5O5V10EEf61sHCw4IZ/MaLJNg=
+github.com/jibutech/backup-saas-client v0.0.2-0.20211210113648-e89028c38b38/go.mod h1:AXpj+/dCZ5hSmV9tg4yFQLAKGRsAyf9lhCxwA+4pMy8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
-github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
@@ -186,7 +180,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
@@ -214,6 +207,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -310,7 +305,6 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5 h1:Ati8dO7+U7mxpkPSxBZQEvzHVUYB/MqCklCN8ig5w/o=
 golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -445,7 +439,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
@@ -502,7 +495,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
@@ -544,7 +536,6 @@ k8s.io/client-go v0.22.4 h1:aAQ1Wk+I3bjCNk35YWUqbaueqrIonkfDPJSPDDe8Kfg=
 k8s.io/client-go v0.22.4/go.mod h1:Yzw4e5e7h1LNHA4uqnMVrpEpUs1hJOiuBsJKIlRCHDA=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
-k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/klog/v2 v2.30.0 h1:bUO6drIvCIsvZ/XFgfxoGFQU/a4Qkh0iAlvUR7vlHJw=
 k8s.io/klog/v2 v2.30.0/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
@@ -556,7 +547,6 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
-sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.0 h1:kDvPBbnPk+qYmkHmSo8vKGp438IASWofnbbUKDE/bv0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.0/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/test/jibu/args.go
+++ b/test/jibu/args.go
@@ -3,38 +3,60 @@ package jibu
 import (
 	"context"
 	"flag"
+	"fmt"
 	"time"
+
+	"github.com/robfig/cron/v3"
 )
 
 const (
-	resourcePickRetryLimit    = 10
-	jobRetention              = 240
-	backupPlanReadyTimeout    = 5 * time.Minute
-	backupJobFinishedTimeout  = 2 * time.Hour
-	restorePlanReadyTimeout   = 5 * time.Minute
-	restoreJobFinishedTimeout = 2 * time.Hour
-	actionStartJob            = "StartJob"
+	resourcePickRetryLimit           = 10
+	jobRetention                     = 240
+	backupPlanReadyTimeout           = 5 * time.Minute
+	backupJobRepeatedCreationTimeout = 3 * time.Minute
+	backupJobFinishedTimeout         = 2 * time.Hour
+	restorePlanReadyTimeout          = 5 * time.Minute
+	restoreJobFinishedTimeout        = 2 * time.Hour
+	actionStartJob                   = "StartJob"
 )
 
 // flags
 var (
-	argTenant = flag.String("jibu-tenant", "1", "tenant id")
-	argJibuAPIEndpoint = flag.String("jibu-api-endpoint", "http://localhost:31800", "jibu api endpoint")
-	argExcludeNamespaces = flag.String("jibu-exclude-namespaces", "kube-system,kube-public,kube-node-lease,qiming-backend,backup-saas-system", "exclude namespaces for backup and restore, separated by comma")
+	argTenant                 = flag.String("jibu-tenant", "1", "tenant id")
+	argJibuAPIEndpoint        = flag.String("jibu-api-endpoint", "http://localhost:31800", "jibu api endpoint")
+	argExcludeNamespaces      = flag.String("jibu-exclude-namespaces", "kube-system,kube-public,kube-node-lease,qiming-backend,backup-saas-system", "exclude namespaces for backup and restore, separated by comma")
 	argRestoreToSameNamespace = flag.Bool("jibu-restore-same-namespace", false, "restore uses same namespace as backup")
-	argBackupWithPV = flag.Bool("jibu-backup-with-pv", true, "backup with pv")
-	argBackupNamespace = flag.String("jibu-backup-namespace", "", "if set, backup specified namespace")
-	argRestoreNamespace = flag.String("jibu-restore-namespace", "", "if set, restore to the specified namespace")
-	argSkipBackup = flag.Bool("jibu-skip-backup", false, "if set, skip backup test")
-	argSkipRestore = flag.Bool("jibu-skip-restore", false, "if set, skip restore test")
-	argBackupCluster = flag.String("jibu-backup-cluster", "", "if set, use specified cluster for backup")
-	argRestoreCluster = flag.String("jibu-restore-cluster", "", "if set, use specified cluster for restore")
-	argStorage = flag.String("jibu-storage", "", "if set, use specified storage during test")
-	argCleanUpOnEnd = flag.Bool("jibu-clean-up-on-end", true, "clean up after test, including delete backup/restore jobs, delete restored namespace etc.")
-	argBackupPlanName = flag.String("jibu-backup-plan-name", "", "backup plan name, if not set, will use backup-{timestamp}")
-	argBackupJobName = flag.String("jibu-backup-job-name", "", "backup job name, if not set, will use {backup-plan-name}-{random-string}")
-	argRestorePlanName = flag.String("jibu-restore-plan-name", "", "restore plan name, if not set, will use restore-{timestamp}")
-	argRestoreJobName = flag.String("jibu-restore-job-name", "", "restore job name, if not set, will use {restore-plan-name}-{random-string}")
+	argBackupRepeatEnabled    = flag.Bool("jibu-backup-repeat-enabled", false, "whether to create a repeted backupplan")
+	argBackupFrequency        = flag.String("jibu-backup-frequency", "*/3 * * * *", "the frequency(crontab string) to create backup jobs, defaults to every 3 minutes for faster testing, only effective when backup-repeat-enabled is set to true")
+	argBackupRepeatCheckNum   = flag.Int("jibu-bakcup-repeat-check-num", 3, "the number of times to check the creation of the repeated backupjob")
+	argBackupWithPV           = flag.Bool("jibu-backup-with-pv", true, "backup with pv")
+	argBackupCopyMethod       = flag.String("jibu-backup-method", string(BackupCopyMethodFilesystem), "copy method of backup for PVs, defaults to filesystem(restic)")
+	argBackupNamespace        = flag.String("jibu-backup-namespace", "", "if set, backup specified namespace")
+	argRestoreNamespace       = flag.String("jibu-restore-namespace", "", "if set, restore to the specified namespace")
+	argSkipBackup             = flag.Bool("jibu-skip-backup", false, "if set, skip backup test")
+	argSkipRestore            = flag.Bool("jibu-skip-restore", false, "if set, skip restore test")
+	argBackupCluster          = flag.String("jibu-backup-cluster", "", "if set, use specified cluster for backup")
+	argRestoreCluster         = flag.String("jibu-restore-cluster", "", "if set, use specified cluster for restore")
+	argStorage                = flag.String("jibu-storage", "", "if set, use specified storage during test")
+	argCleanUpOnEnd           = flag.Bool("jibu-clean-up-on-end", true, "clean up after test, including delete backup/restore jobs, delete restored namespace etc.")
+	argBackupPlanName         = flag.String("jibu-backup-plan-name", "", "backup plan name, if not set, will use backup-{timestamp}")
+	argBackupJobName          = flag.String("jibu-backup-job-name", "", "backup job name, if not set, will use {backup-plan-name}-{random-string}")
+	argRestorePlanName        = flag.String("jibu-restore-plan-name", "", "restore plan name, if not set, will use restore-{timestamp}")
+	argRestoreJobName         = flag.String("jibu-restore-job-name", "", "restore job name, if not set, will use {restore-plan-name}-{random-string}")
 )
 
 var ctx = context.Background()
+
+func validateFlags() error {
+	if *argBackupCopyMethod != string(BackupCopyMethodFilesystem) && *argBackupCopyMethod != string(BackupCopyMethodSnapshot) {
+		return fmt.Errorf("invalid backup copy method: %s", *argBackupCopyMethod)
+	}
+
+	if *argBackupRepeatEnabled {
+		if _, err := cron.ParseStandard(*argBackupFrequency); err != nil {
+			return fmt.Errorf("invalid backup frequency %s: %v", *argBackupFrequency, err)
+		}
+	}
+
+	return nil
+}

--- a/test/jibu/types.go
+++ b/test/jibu/types.go
@@ -27,3 +27,29 @@ const (
 	// JobSubmitted means a job is submitted to backend controller
 	JobPhaseSubmitted PhaseType = "JobSubmitted"
 )
+
+type BackupCopyMethod string
+
+const (
+	BackupCopyMethodFilesystem BackupCopyMethod = "filesystem"
+	BackupCopyMethodSnapshot   BackupCopyMethod = "snapshot"
+)
+
+const (
+	FieldName                = "name"
+	FieldNames               = "names"
+	FieldUID                 = "uid"
+	FieldCreationTimeStamp   = "creationTimestamp"
+	FieldCreateTime          = "createTime"
+	FieldLastUpdateTimestamp = "lastUpdateTimestamp"
+	FieldUpdateTime          = "updateTime"
+	FieldLabel               = "label"
+	FieldAnnotation          = "annotation"
+	FieldNamespace           = "namespace"
+	FieldStatus              = "status"
+	FieldOwnerReference      = "ownerReference"
+	FieldOwnerKind           = "ownerKind"
+	FieldDeletionTimestamp   = "deletionTimestamp"
+
+	FieldType = "type"
+)


### PR DESCRIPTION
Signed-off-by: dkeven <keven@kubesphere.io>

This PR adds:

a `jibu-backup-method` flag to support csi snapshot copy method, in addition to the existing `filesystem`

a `jibu-backup-repeat-enabled` flag to support repeated backup plan, as well as a  `jibu-backup-frequency` flag to specify the cronjob str, and a `jibu-bakcup-repeat-check-num` flag to specify how many times to check the repeatedly created backup jobs.

after the test, all of the backup jobs and restore jobs will be deleted.

if the backup plan is repeated, it will also get deleted.